### PR TITLE
[bugfix] non-nullable apiKeyID

### DIFF
--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -14,12 +14,12 @@ import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 
 class API {
-  String? apiKeyID;
+  String apiKeyID;
 
   API({required this.apiKeyID});
 
-  Map<String, String?> headers() {
-    Map<String, String?> headers = {
+  Map<String, String> headers() {
+    Map<String, String> headers = {
       'API_KEY_ID': this.apiKeyID,
       'Content-Type': 'application/json',
     };
@@ -34,8 +34,8 @@ class API {
       "identifier": identifier,
     };
 
-    final http.Response response = await http.post(uri,
-        headers: this.headers() as Map<String, String>?, body: jsonEncode(req));
+    final http.Response response =
+        await http.post(uri, headers: this.headers(), body: jsonEncode(req));
 
     if (response.statusCode == 200) {
       User resp = User.fromJson(json.decode(response.body));
@@ -48,8 +48,7 @@ class API {
   Future<User> getUserByIdentifier(String identifier) async {
     final uri = Uri.parse(
         '${Cotter.baseURL}/user?identifier=${Uri.encodeComponent(identifier)}');
-    final http.Response response =
-        await http.get(uri, headers: this.headers() as Map<String, String>?);
+    final http.Response response = await http.get(uri, headers: this.headers());
 
     if (response.statusCode == 200) {
       User resp = User.fromJson(json.decode(response.body));
@@ -125,8 +124,8 @@ class API {
     };
 
     final uri = Uri.parse(url);
-    final http.Response response = await http.put(uri,
-        headers: this.headers() as Map<String, String>?, body: jsonEncode(req));
+    final http.Response response =
+        await http.put(uri, headers: this.headers(), body: jsonEncode(req));
 
     if (response.statusCode == 200) {
       return json.decode(response.body);
@@ -169,8 +168,7 @@ class API {
   Future<bool?> checkEnrolledMethod(
       {required String url, required String method}) async {
     final uri = Uri.parse(url);
-    final http.Response response =
-        await http.get(uri, headers: this.headers() as Map<String, String>?);
+    final http.Response response = await http.get(uri, headers: this.headers());
 
     if (response.statusCode == 200) {
       Map<String, dynamic> resp = json.decode(response.body);
@@ -206,8 +204,8 @@ class API {
   Future<Map<String, dynamic>?> createEventRequest(
       String path, Map<String, dynamic> req) async {
     final uri = Uri.parse("${Cotter.baseURL}$path");
-    final http.Response response = await http.post(uri,
-        headers: this.headers() as Map<String, String>?, body: jsonEncode(req));
+    final http.Response response =
+        await http.post(uri, headers: this.headers(), body: jsonEncode(req));
 
     if (response.statusCode == 200) {
       return json.decode(response.body);
@@ -224,8 +222,8 @@ class API {
     };
 
     final uri = Uri.parse("${Cotter.baseURL}$path");
-    final http.Response response = await http.post(uri,
-        headers: this.headers() as Map<String, String>?, body: jsonEncode(req));
+    final http.Response response =
+        await http.post(uri, headers: this.headers(), body: jsonEncode(req));
 
     if (response.statusCode == 200) {
       var resp = json.decode(response.body);
@@ -239,8 +237,7 @@ class API {
   Future<Map<String, dynamic>?> getEvent(String eventID) async {
     var path = '/event/get/$eventID?oauth_token=true';
     final uri = Uri.parse("${Cotter.baseURL}$path");
-    final http.Response response =
-        await http.get(uri, headers: this.headers() as Map<String, String>?);
+    final http.Response response = await http.get(uri, headers: this.headers());
 
     if (response.statusCode == 200) {
       return json.decode(response.body);
@@ -263,8 +260,7 @@ class API {
     }
 
     final uri = Uri.parse("${Cotter.baseURL}$path");
-    final http.Response response =
-        await http.get(uri, headers: this.headers() as Map<String, String>?);
+    final http.Response response = await http.get(uri, headers: this.headers());
 
     if (response.statusCode == 200) {
       var resp = json.decode(response.body);
@@ -295,8 +291,8 @@ class API {
     };
 
     final uri = Uri.parse("${Cotter.baseURL}$path");
-    final http.Response response = await http.post(uri,
-        headers: this.headers() as Map<String, String>?, body: jsonEncode(req));
+    final http.Response response =
+        await http.post(uri, headers: this.headers(), body: jsonEncode(req));
 
     if (response.statusCode == 200) {
       return json.decode(response.body);

--- a/lib/src/handlers/device.dart
+++ b/lib/src/handlers/device.dart
@@ -16,7 +16,7 @@ import 'package:cotter/src/helper/storage.dart';
 class Device {
   static final String _publicKey = "COTTER_DEVICE_PUBLIC_KEY";
   static final String _privateKey = "COTTER_DEVICE_PRIVATE_KEY";
-  String? apiKeyID;
+  String apiKeyID;
 
   Device({required this.apiKeyID});
 
@@ -24,14 +24,14 @@ class Device {
     if (userID == null) {
       throw "User ID is not specified, please specify user ID before calling other methods";
     }
-    return _publicKey + this.apiKeyID! + userID;
+    return _publicKey + this.apiKeyID + userID;
   }
 
   String _getKeyStoreAliasPrivateKey(String? userID) {
     if (userID == null) {
       throw "User ID is not specified, please specify user ID before calling other methods";
     }
-    return _privateKey + this.apiKeyID! + userID;
+    return _privateKey + this.apiKeyID + userID;
   }
 
   _storeKeys(String pubKey, String privKey, String? userID) async {

--- a/lib/src/handlers/token.dart
+++ b/lib/src/handlers/token.dart
@@ -18,7 +18,8 @@ class Token {
       await Storage.write(key: ACCESS_TOKEN_KEY, value: oAuthToken.accessToken);
       Token.accessToken = new CotterAccessToken(token: oAuthToken.accessToken!);
     }
-    if (oAuthToken.refreshToken != null && oAuthToken.refreshToken!.length > 0) {
+    if (oAuthToken.refreshToken != null &&
+        oAuthToken.refreshToken!.length > 0) {
       await Storage.write(
           key: REFRESH_TOKEN_KEY, value: oAuthToken.refreshToken);
     }
@@ -42,7 +43,7 @@ class Token {
     return Token.accessToken;
   }
 
-  static Future<CotterIDToken?> getIDToken(String? apiKeyID) async {
+  static Future<CotterIDToken?> getIDToken(String apiKeyID) async {
     if (Token.idToken == null) {
       var token = await Storage.read(key: ID_TOKEN_KEY);
       if (token != null) {
@@ -59,7 +60,7 @@ class Token {
   }
 
   static Future<void> refreshIfNeeded(
-      CotterJwtToken? token, String? apiKeyID) async {
+      CotterJwtToken? token, String apiKeyID) async {
     if (token == null || token.isExpired()) {
       var refreshToken = await Token.getRefreshToken();
       if (refreshToken == null) {

--- a/lib/src/handlers/verify.dart
+++ b/lib/src/handlers/verify.dart
@@ -7,13 +7,12 @@ import 'package:cotter/src/helper/web_auth.dart';
 import 'package:cotter/src/tokens/oAuthToken.dart';
 
 class Verify {
-  String? apiKeyID;
+  String apiKeyID;
   String? state;
   String? codeVerifier;
   String? codeChallenge;
 
-  Verify({required String? apiKeyID}) {
-    this.apiKeyID = apiKeyID;
+  Verify({required this.apiKeyID}) {
     this.state = _generateState();
     var codeVerifier = RandomString.createCodeVerifier();
     this.codeVerifier = codeVerifier;

--- a/lib/src/models/user.dart
+++ b/lib/src/models/user.dart
@@ -67,7 +67,7 @@ class User {
     user.cotter = cotter;
     // if this fails, then the user is not logged-in
     // or the refresh token failed to refresh
-    await Token.getIDToken(user.issuer);
+    await Token.getIDToken(user.issuer!);
     return user;
   }
 
@@ -75,12 +75,12 @@ class User {
 
   // Sign up with this device, identifier can be user's email, phone, or any string to identify your user
   Future<User> registerDevice() {
-    Device device = new Device(apiKeyID: this.issuer);
+    Device device = new Device(apiKeyID: this.issuer!);
     return device.registerDevice(user: this);
   }
 
   Future<Event?> checkNewSignInRequest({required BuildContext context}) {
-    Device device = new Device(apiKeyID: this.issuer);
+    Device device = new Device(apiKeyID: this.issuer!);
     if (this.cotter == null) {
       throw "Cotter is not specified, either call `user = await cotter.getUser(); user.checkNewSignInRequest(context)` or `user.WithCotter(cotter).checkNewSignInRequest(context)`. This allows you to pass strings and colors into the Cotter object to be used in the approve sign in modal.";
     }
@@ -89,7 +89,7 @@ class User {
   }
 
   Future<bool?> isThisDeviceTrusted() async {
-    Device device = new Device(apiKeyID: this.issuer);
+    Device device = new Device(apiKeyID: this.issuer!);
     return await device.isThisDeviceTrusted(cotterUserID: this.id);
   }
 
@@ -97,13 +97,14 @@ class User {
 
   /// Verify user email with OTP.
   Future<User> verifyEmailWithOTP({required String redirectURL}) {
-    Verify verify = new Verify(apiKeyID: this.issuer);
-    return verify.verifyEmail(redirectURL: redirectURL, email: this.identifier!);
+    Verify verify = new Verify(apiKeyID: this.issuer!);
+    return verify.verifyEmail(
+        redirectURL: redirectURL, email: this.identifier!);
   }
 
   /// Verify user email with OTP via text messages (SMS).
   Future<User> verifyPhoneWithOTPViaSMS({required String redirectURL}) {
-    Verify verify = new Verify(apiKeyID: this.issuer);
+    Verify verify = new Verify(apiKeyID: this.issuer!);
     return verify.verifyPhone(
       redirectURL: redirectURL,
       phone: this.identifier!,
@@ -113,7 +114,7 @@ class User {
 
   /// Verify user email with OTP via text messages (WhatsApp).
   Future<User> verifyPhoneWithOTPViaWhatsApp({required String redirectURL}) {
-    Verify verify = new Verify(apiKeyID: this.issuer);
+    Verify verify = new Verify(apiKeyID: this.issuer!);
     return verify.verifyPhone(
       redirectURL: redirectURL,
       phone: this.identifier!,


### PR DESCRIPTION
## Bug Description
When calling the SDK, an exception is thrown due to an incompatible typecast. This occurs in setting the headers in HTTP calls to the Cotter API. 

For example, in calling:
```
try {
  var user = await cotter.signUpWithPhoneOTP( // package:metta/pages/login_page.dart:27
    redirectURL: "<scheme>://auth_callback",
    channels: [PhoneChannel.SMS],
  );
  print(user);
} catch (e) {
  print(e);
}
```

The following exception is thrown:
```[VERBOSE-2:ui_dart_state.cc(199)] Unhandled Exception: type '_InternalLinkedHashMap<String, String?>' is not a subtype of type 'Map<String, String>?' in type cast
#0      API.getIdentity
package:cotter/src/api.dart:299
#1      Verify._processRedirectURL
package:cotter/…/handlers/verify.dart:147
#2      Verify.signUpWithPhone
package:cotter/…/handlers/verify.dart:88
<asynchronous suspension>
#3      _LoginPageState.login
package:metta/pages/login_page.dart:27
```

this is due to the following typecast:
```
headers: this.headers() as Map<String, String>?
```

### Solution
Set `apiKeyId` to non-nullable. At the top level, `apiKeyId` is a non-nullable String when initializing the SDK so this shouldn't have any consequences on type-safety.