### PR TITLE
fix: export the exceptions handler

### DIFF
--- a/lib/cotter.dart
+++ b/lib/cotter.dart
@@ -1,5 +1,7 @@
 library cotter;
 
+export 'src/exceptions/token.dart';
+export 'src/exceptions/user.dart';
 export 'src/cotter.dart';
 export 'src/models/user.dart';
 export 'src/models/event.dart';


### PR DESCRIPTION
I got difficulties getting the exception clause, caused it's not exported before.